### PR TITLE
author on post is now link to author details page

### DIFF
--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -14,7 +14,7 @@ export default ({ post, setPost }) => {
             </h3>
             </div>
             <section className="message-body">
-            <div> By: {post.user?.user?.first_name} {post.user?.user?.last_name} </div>
+            <div> By: <Link to={`/users/${post.user?.id}`}>{post.user?.user?.first_name} {post.user?.user?.last_name}</Link></div>
             <div> In {post.category.label} category </div>
             <div>Tagged {post.tags?.map(t => t.label)}</div>
             <Link to={`/my-posts/editpost/${post.id}`}><button className="button mr-3 my-3">Edit Post</button></Link>


### PR DESCRIPTION
# Description

modified the post list so that the displayed author of a post is now a link to that authors detail page.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

as an author, navigate to the posts list and click on the name of any author on any post. it will take you to their details page.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
