### PR TITLE
Authors on posts linked to author detail page

### DIFF
--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -14,7 +14,7 @@ export default ({ post, setPost }) => {
             </h3>
             </div>
             <section className="message-body">
-            <div> By: {post.user?.user?.first_name} {post.user?.user?.last_name} </div>
+            <div> By: <Link to={`/users/${post.user?.id}`}>{post.user?.user?.first_name} {post.user?.user?.last_name}</Link></div>
             <div> In {post.category.label} category </div>
             <div>Tagged {post.tags?.map(t => t.label)}</div>
             <Link to={`/my-posts/editpost/${post.id}`}><button className="button mr-3 my-3">Edit Post</button></Link>

--- a/src/components/users/UserDetails.js
+++ b/src/components/users/UserDetails.js
@@ -66,6 +66,7 @@ export const UserDetails = () => {
                             <div> Bio: {author.bio} </div>
                             <div>Created on: {author.user?.date_joined}</div>
                             <div> Username: {author.user?.username} </div>
+                            <div> Type: {author.user?.is_staff ? "Admin" : "Author"}</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
# Description

displayed author name on post is now link to that authors detail page. admin or author is display on detail card now a well.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

as a user go to posts page and click on the name of the author on one of the posts. you should be navigated to that authors detail page and it should show at the bottom of the card whether they area an admin or author.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
