### PR TITLE
added cancel button on edit post form, cleaned up button/link css on posts

### DIFF
--- a/src/components/posts/EditPostForm.js
+++ b/src/components/posts/EditPostForm.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { useHistory } from "react-router"
-import { useParams } from "react-router-dom"
+import { useParams, Link } from "react-router-dom"
 import { getCategories } from "../categories/CategoryManager"
 import { getTags } from "../tags/TagManager"
 import { getSinglePost, updatePost } from "./PostManager"
@@ -169,6 +169,9 @@ export const EditPostForm = () => {
                 </div>
                 <button type="button" className="button is-link has-text-weight-bold" onClick={() => updatePostInfo()}>
                     Submit
+                </button>
+                <button type="button" className="button is-link has-text-weight-bold" onClick={() => (history.push("/posts"))}>
+                    Cancel
                 </button>
             </form>
         </div>

--- a/src/components/posts/Post.js
+++ b/src/components/posts/Post.js
@@ -22,22 +22,23 @@ export default ({ post, setPost, admin }) => {
             <div>Tagged {post.tags?.map(t => t.label)}</div>
             {
                 (admin && post.approved) === false ?
-                <button onClick={()=> {approvePost(post.id).then(setPost)}}>Approve Post</button>
+                <button className="button mr-3 my-3" onClick={()=> {approvePost(post.id).then(setPost)}}>Approve Post</button>
                 : 
                 ""
             }
             {
                 (admin && post.user?.user?.is_staff === false && post.approved === true) ?
-                <button onClick={()=> {unapprovePost(post.id).then(setPost)}}>Unapprove Post</button>
+                <button className="button mr-3 my-3" onClick={()=> {unapprovePost(post.id).then(setPost)}}>Unapprove Post</button>
                 : 
                 ""
             }
-            <Link to={`/my-posts/editpost/${post.id}`}><button className="button mr-3 my-3">Edit Post</button></Link>
+            <button className="button mr-3 my-3" onClick={() => {history.push(`/my-posts/editpost/${post.id}`)}}>Edit Post</button>
             <button className="button mr-3 my-3" onClick={() => {
                                         deletePost(post.id)
                                             .then(setPost)
                                     }}>Delete Post</button>
-            <Link to={`/commentCreate/${post.id}`}><button className="button mr-3 my-3">New Comment?</button></Link>
+            <button className="button mr-3 my-3" onClick={() => {history.push(`/comments/${post.id}`)}}>View Comments</button>
+
             </section>
         </section>
     )

--- a/src/components/posts/PostDetails.js
+++ b/src/components/posts/PostDetails.js
@@ -35,7 +35,7 @@ export const PostDetails = () => {
                     <div> In {post.category?.label} category </div>
                     <div>Tagged {post.tags?.map(t => t.label)}</div>
                     <div><Link to={`/comments/${postId}`}>View Comments</Link></div>
-                    <div><Link to={`/commentCreate/${postId}`}>Add Comments</Link></div>
+                    <div><Link to={`/commentCreate/${postId}`}>New Comment</Link></div>
                     {
                         post.user?.id === currentUser?.id
                             ? <>


### PR DESCRIPTION
# Description

added a cancel button on the edit post form to bring you back to the posts page
added a view comments button on posts page
cleaned up some button/link css and posts page

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

as a author or admin login and navigate to the posts page
click on edit post button on one of your posts
there should be a cancel button that when clicked, routes you back to the post list
there should also be a view comments button on the post list instead of add comment

as an admin, the approve/unapprove buttons style should match the other buttons.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
