### PR TITLE
Two admins approval

### DIFF
--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -1,10 +1,8 @@
 import React, { useState } from "react"
-import { useHistory } from "react-router-dom"
 import { Link } from "react-router-dom"
 import { activate, deactivate, makeAdmin, makeAuthor, getUsers } from "./UserManager"
 
 export const User = ({ rareUser, currentUser, setUsers }) => {
-    const history = useHistory()
 
     return (
         <div className="column is-one-third">

--- a/src/components/users/User.js
+++ b/src/components/users/User.js
@@ -1,8 +1,39 @@
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
-import { activate, deactivate, makeAdmin, makeAuthor, getUsers } from "./UserManager"
+import { activate, deactivate, makeAdmin, makeAuthor, getUsers, getDeactivationsByAdmin, createDemotion, createDeactivation, deleteDemotion, getDemotionsByAdmin, deleteDeactivation } from "./UserManager"
 
 export const User = ({ rareUser, currentUser, setUsers }) => {
+    const [adminDeactivation, setAdminDeactivation] = useState(null)
+    const [adminDemotion, setAdminDemotion] = useState(null)
+
+    useEffect(() => {
+        if (rareUser.user?.is_staff) {
+            getDeactivationsByAdmin(rareUser.id)
+                .then((res) => {
+                    if (res[0]) {
+                        setAdminDeactivation(res[0])
+                    }
+                })
+            getDemotionsByAdmin(rareUser.id)
+                .then((res) => {
+                    if (res[0]) {
+                        setAdminDemotion(res[0])
+                    }
+                })
+        }
+    }, []
+    )
+
+    const canDeactivate = () => {
+        if (rareUser.user.is_staff && rareUser.active && adminDeactivation?.requester !== currentUser.id) {
+            return true
+        } else if (rareUser.user.is_staff === false && rareUser.active) {
+            return true
+        } else {
+            return false
+        }
+    }
+
 
     return (
         <div className="column is-one-third">
@@ -21,61 +52,116 @@ export const User = ({ rareUser, currentUser, setUsers }) => {
                         Email: {rareUser.user.email}
                     </div>
                     <div className="content has-text-white">
-                        {rareUser.user?.is_staff
-                            ? <>
-                                <p> Permissions: Admin</p>
-                                <button
-                                    className="button is-small"
-                                    onClick={() =>
-                                        makeAuthor(rareUser.id)
-                                        .then((res)=> {
-                                            if (res.status === 409){
-                                                window.alert("Cannot be changed- this is the only active admin remaining")
+                        {
+                            //Permissions promotion/demotions
+                            rareUser.user.is_staff && adminDemotion === null
+                                ? <>
+                                    <p> Permissions: Admin</p>
+                                    <button
+                                        className="button is-small"
+                                        onClick={() =>
+                                            //This will need extra approval
+                                            createDemotion(rareUser.id)
+                                                .then(() => getDemotionsByAdmin(rareUser.id)
+                                                    .then((res) => {
+                                                        if (res[0]) {
+                                                            setAdminDemotion(res[0])
+                                                        }
+                                                    }))
+                                        }
+                                    >Request Demote</button>
+                                </>
+                                : rareUser.user.is_staff && adminDemotion?.requester !== currentUser.id
+                                    ? <>
+                                        <p> Permissions: Admin</p>
+                                        <div className="notification is-link p-1"> Demotion Requested</div>
+                                        <button
+                                            className="button is-small"
+                                            onClick={() =>
+                                                makeAuthor(rareUser.id)
+                                                    .then((res) => {
+                                                        if (res.status === 409) {
+                                                            window.alert("Cannot be changed- this is the only active admin remaining")
+                                                        } else {
+                                                            deleteDemotion(adminDemotion.id)
+                                                                .then(() => setAdminDemotion(null))
+                                                        }
+                                                    })
+                                                    .then(getUsers).then(setUsers)
                                             }
-                                        })
-                                        .then(getUsers).then(setUsers)
-                                    }
-                                >Demote</button>
-                            </>
-                            : <>
-                                <p> Permissions: Author</p>
-                                <button
-                                    className="button is-small"
-                                    onClick={() =>
-                                        makeAdmin(rareUser.id)
-                                        .then(getUsers).then(setUsers)
-                                    }
-                                >Promote</button>
-                            </>
+                                        > Demote</button>
+                                    </>
+                                    : adminDemotion?.requester === currentUser.id
+                                        ? <div className="notification is-link p-1 m-0"> You have requested demotion</div>
+                                        : <>
+                                            <p> Permissions: Author</p>
+                                            <button
+                                                className="button is-small"
+                                                onClick={() =>
+                                                    makeAdmin(rareUser.id)
+                                                        .then(getUsers).then(setUsers)
+                                                }
+                                            >Promote</button>
+                                        </>
                         }
                     </div>
                     <div className="content has-text-white">
-                        {rareUser.active
-                            ? <>
-                                <p> Status: Active</p>
-                                <button
-                                    className="button is-small"
-                                    onClick={() =>
-                                        deactivate(rareUser.id)
-                                        .then((res)=> {
-                                            if (res.status === 409){
-                                                window.alert("Cannot be changed- this is the only active admin remaining")
+                        {
+                            //Permissions promotion/demotions
+                            rareUser.user.is_staff && adminDeactivation === null && rareUser.active
+                                ? <>
+                                    <p> Status: Active</p>
+                                    <button
+                                        className="button is-small"
+                                        onClick={() =>
+                                            //This will need extra approval
+                                            createDeactivation(rareUser.id)
+                                                .then(() => getDeactivationsByAdmin(rareUser.id)
+                                                    .then((res) => {
+                                                        if (res[0]) {
+                                                            setAdminDeactivation(res[0])
+                                                        }
+                                                    }))
+                                        }
+                                    >Request Deactivation</button>
+                                </>
+                                : canDeactivate()
+                                    ? <>
+                                        <p> Status: Active</p>
+                                        {
+                                            rareUser.user?.is_staff 
+                                            ? <div className="notification is-link p-1"> Deactivation Requested</div>
+                                            : ""
+                                        }
+                                        <button
+                                            className="button is-small"
+                                            onClick={() =>
+                                                //This will need extra approval
+                                                deactivate(rareUser.id)
+                                                    .then((res) => {
+                                                        if (res.status === 409) {
+                                                            window.alert("Cannot be changed- this is the only active admin remaining")
+                                                        } else if (rareUser.user?.is_staff) {
+                                                            deleteDeactivation(adminDeactivation.id)
+                                                                .then(() => setAdminDeactivation(null))
+                                                        }
+                                                    })
+                                                    .then(getUsers).then(setUsers)
                                             }
-                                        })
-                                        .then(getUsers).then(setUsers)
-                                    }
-                                >Deactivate</button>
-                            </>
-                            : <>
-                                <p> Status: Inactive</p>
-                                <button
-                                    className="button is-small"
-                                    onClick={() =>
-                                        activate(rareUser.id)
-                                        .then(getUsers).then(setUsers)
-                                    }
-                                >Activate</button>
-                            </>
+                                        > Deactivate</button>
+                                    </>
+                                    : adminDeactivation?.requester === currentUser.id
+                                        ? <div className="notification is-link p-1 m-0"> You have requested deactivation</div>
+                                        : <>
+                                            <p> Status: Inactive</p>
+                                            <button
+                                                className="button is-small"
+                                                onClick={() =>
+                                                    activate(rareUser.id)
+                                                        .then(getUsers).then(setUsers)
+                                                }
+                                            >Activate</button>
+                                        </>
                         }
                     </div>
                 </div>

--- a/src/components/users/UserManager.js
+++ b/src/components/users/UserManager.js
@@ -25,8 +25,8 @@ export const getCurrentUser = () => {
         .then(res => res.json())
 }
 
-export const getDemotionByAdmin = (adminId) => {
-    return fetch(`http://localhost:8000/demotion/${adminId}`, {
+export const getDemotionsByAdmin = (adminId) => {
+    return fetch(`http://localhost:8000/demotions?adminId=${adminId}`, {
         headers: {
             "Authorization": `Token ${localStorage.getItem("rare_token")}`
         }
@@ -34,8 +34,8 @@ export const getDemotionByAdmin = (adminId) => {
         .then(res => res.json())
 }
 
-export const getDeactivationByAdmin = (adminId) => {
-    return fetch(`http://localhost:8000/demotion/${adminId}`, {
+export const getDeactivationsByAdmin = (adminId) => {
+    return fetch(`http://localhost:8000/deactivations?adminId=${adminId}`, {
         headers: {
             "Authorization": `Token ${localStorage.getItem("rare_token")}`
         }

--- a/src/components/users/UserManager.js
+++ b/src/components/users/UserManager.js
@@ -25,6 +25,72 @@ export const getCurrentUser = () => {
         .then(res => res.json())
 }
 
+export const getDemotionByAdmin = (adminId) => {
+    return fetch(`http://localhost:8000/demotion/${adminId}`, {
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("rare_token")}`
+        }
+    })
+        .then(res => res.json())
+}
+
+export const getDeactivationByAdmin = (adminId) => {
+    return fetch(`http://localhost:8000/demotion/${adminId}`, {
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("rare_token")}`
+        }
+    })
+        .then(res => res.json())
+}
+
+export const deleteDemotion = demotionId => {
+    return fetch(`http://localhost:8000/demotions/${demotionId}`, {
+        method: "DELETE",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("rare_token")}`
+        }
+    })
+    
+};
+
+export const deleteDeactivation = deactivationId => {
+    return fetch(`http://localhost:8000/deactivations/${deactivationId}`, {
+        method: "DELETE",
+        headers: {
+            "Authorization": `Token ${localStorage.getItem("rare_token")}`
+        }
+    })
+    
+};
+
+export const createDemotion = (adminId) => {
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("rare_token")}`
+        },
+        body: JSON.stringify({admin: adminId})
+    }
+    return fetch(`http://localhost:8000/demotions`, fetchOptions)
+        .then(res => res.json())
+}
+
+export const createDeactivation = (adminId) => {
+    const fetchOptions = {
+        method: "POST",
+        headers: {
+            "content-Type": "application/json",
+            "Authorization": `Token ${localStorage.getItem("rare_token")}`
+        },
+        body: JSON.stringify({admin: adminId})
+    }
+    return fetch(`http://localhost:8000/deactivations`, fetchOptions)
+        .then(res => res.json())
+}
+
+
+
 export const subscribe = (id) => {
     const fetchOptions = {
         method: "POST",


### PR DESCRIPTION
# Description

Two admins must agree when demoting or deactivating an admin. The first request will show an alert saying it's been requested. The second admin will see an alert saying approval was requested, then will be able to move forward with the demotion/deactivation

Currently, requesting both a deactivation and a demotion on an admin will lead to only one of those being able to be approved. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A- tested in browser with multiple admin profiles and multiple combinations
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
